### PR TITLE
added nose arguments

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,10 @@
 [nosetests]
-verbosity=1
+verbosity=2 
+with-spec=1
+spec-color=1 
+with-coverage=1 
+cover-erase=1 
+cover-package=service
 
 [coverage:report]
 show_missing = True


### PR DESCRIPTION
Setup.cfg file was configured to have nosetests display in color by default